### PR TITLE
fixes to the testing dbs setup

### DIFF
--- a/src/Chirp.Tests/WebAppFactory.cs
+++ b/src/Chirp.Tests/WebAppFactory.cs
@@ -7,30 +7,46 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Chirp.Tests;
 
-public class WebAppFactory : WebApplicationFactory<Chirp.Web.Program>
+public class WebAppFactory : WebApplicationFactory<Chirp.Web.Program>, IDisposable
 {
+    private readonly SqliteConnection _connection;
+
+    public WebAppFactory()
+    {
+        // Keep the same in-memory database alive for the factory’s lifetime
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.ConfigureServices(services =>
         {
-            // Remove app's DbContext registration
+            // Remove the existing DbContext registration
             var descriptor = services.SingleOrDefault(
                 d => d.ServiceType == typeof(DbContextOptions<ChirpDbContext>));
             if (descriptor is not null)
                 services.Remove(descriptor);
 
-            // Use in-memory SQLite for tests
-            var connection = new SqliteConnection("DataSource=:memory:");
-            connection.Open();
+            // Use the shared connection
+            services.AddDbContext<ChirpDbContext>(o => o.UseSqlite(_connection));
 
-            services.AddDbContext<ChirpDbContext>(o => o.UseSqlite(connection));
-
-            // Ensure database and seed
+            // Build the service provider and seed the database
             var sp = services.BuildServiceProvider();
             using var scope = sp.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ChirpDbContext>();
-            db.Database.EnsureCreated();
-            DbInitializer.SeedDatabase(db);
+            db.Database.EnsureCreated();  // Creates tables if they don't exist
+            DbInitializer.SeedDatabase(db);  // Seed once
         });
+    }
+
+    // Properly dispose of the shared connection
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing)
+        {
+            _connection.Dispose();
+        }
     }
 }


### PR DESCRIPTION
Fixes current problems with testing as the in-memory db for testing purposes was setup.
Problem with seeding logic and problem with EFMigrationHistory were both caused by mutiple databases being made pr test suite run. This should clear that.
The making and opening of the sqlite connection is tied directly to the factory (it is in the factory's constructor) and it should not make more than one database. It should also be protected from the garbage collector as the database is seen as in use throughout the whole testing operation.