### PR TITLE
In memory db

### DIFF
--- a/src/Chirp.Tests/WebAppFactory.cs
+++ b/src/Chirp.Tests/WebAppFactory.cs
@@ -38,7 +38,7 @@ public class WebAppFactory : WebApplicationFactory<Chirp.Web.Program>, IDisposab
             using var scope = sp.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ChirpDbContext>();
 
-            db.Database.EnsureCreated();
+            db.Database.Migrate();
             DbInitializer.SeedDatabase(db);
         });
 


### PR DESCRIPTION
Fixes to bugfixes...
In-memory database for testing got to work on singular machines, but did not work on github actions/workflows.
Now when the database is made, it is secured against accidentally making multiple DBs with it being a shared named DB.
The DBs are now also randomly named for further troubleshooting.